### PR TITLE
[feat/#32] 검색 및 해시태그 UI/기능 구현

### DIFF
--- a/blog_frontend_react/src/App.jsx
+++ b/blog_frontend_react/src/App.jsx
@@ -17,6 +17,7 @@ import BoardList from "./components/board/BoardList.jsx";
 import BoardDetail from "./components/board/BoardDetail.jsx";
 import BoardWrite from "./components/board/BoardWrite.jsx";
 import "./App.css";
+import SearchPage from "./components/common/SearchPage.jsx";
 
 // 인증이 필요한 라우트 보호 컴포넌트
 function PrivateRoute({ children }) {
@@ -59,6 +60,7 @@ function AppContent() {
           <Route path="/" element={<BoardList />} />
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<Signup />} />
+          <Route path="/search" element={<SearchPage />} />
           <Route
             path="/mypage"
             element={

--- a/blog_frontend_react/src/components/board/BoardDetail.css
+++ b/blog_frontend_react/src/components/board/BoardDetail.css
@@ -206,6 +206,41 @@
   border: 1px solid #e5e7eb;
 }
 
+/* ✅ 태그 리스트 영역 (수정됨) */
+.board-tags-container {
+  margin-top: 3rem;
+  margin-bottom: 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-start; /* 왼쪽 정렬 */
+}
+
+/* ✅ 개별 태그 배지 스타일 (수정됨) */
+.tag-badge {
+  display: inline-flex;
+  align-items: center;
+  height: 2rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  font-size: 1rem;
+  font-weight: 500;
+
+  /* 요청사항 적용: 색상 변함 없음, 짙은 회색 */
+  color: #1f2937 !important;
+  background-color: #f3f4f6;
+
+  border-radius: 1rem;
+  text-decoration: none !important; /* 밑줄 제거 */
+  transition: all 0.2s ease;
+}
+
+/* 태그 호버 효과 (배경색만 살짝 변경) */
+.tag-badge:hover {
+  background-color: #e5e7eb;
+  color: #1f2937 !important; /* 호버시에도 글자색 유지 */
+}
+
 /* 파일 섹션 */
 .file-section {
   display: flex;
@@ -302,6 +337,42 @@
   font-weight: 600;
 }
 
+/* 작성자 정보와 구독 버튼을 감싸는 영역 */
+.writer-wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+/* 구독 버튼 스타일 */
+.subscribe-btn {
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  border-radius: 15px;
+  border: 1px solid #ccc;
+  background-color: white;
+  color: #555;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  line-height: 1;
+}
+
+.subscribe-btn:hover {
+  background-color: #f1f1f1;
+}
+
+/* 구독 중일 때 (활성화) */
+.subscribe-btn.active {
+  background-color: #3b82f6;
+  color: white;
+  border-color: #3b82f6;
+  font-weight: bold;
+}
+
+.subscribe-btn.active:hover {
+  background-color: #2563eb;
+}
+
 /* 반응형 디자인 */
 @media (max-width: 768px) {
   .detail-container {
@@ -343,39 +414,4 @@
     gap: 0.5rem;
     align-items: flex-start;
   }
-}
-/* 작성자 정보와 구독 버튼을 감싸는 영역 */
-.writer-wrapper {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px; /* 닉네임과 버튼 사이 간격 */
-}
-
-/* 구독 버튼 스타일 */
-.subscribe-btn {
-  padding: 4px 10px;
-  font-size: 0.8rem;
-  border-radius: 15px;
-  border: 1px solid #ccc;
-  background-color: white;
-  color: #555;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  line-height: 1;
-}
-
-.subscribe-btn:hover {
-  background-color: #f1f1f1;
-}
-
-/* 구독 중일 때 (활성화) */
-.subscribe-btn.active {
-  background-color: #3b82f6; /* 파란색 */
-  color: white;
-  border-color: #3b82f6;
-  font-weight: bold;
-}
-
-.subscribe-btn.active:hover {
-  background-color: #2563eb;
 }

--- a/blog_frontend_react/src/components/board/BoardDetail.jsx
+++ b/blog_frontend_react/src/components/board/BoardDetail.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { apiDelete, apiGet, apiPost } from "../../../../Blog_Frontend/app";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, Link } from "react-router-dom";
 import {
   checkSubscription,
   toggleSubscription,
@@ -287,7 +287,16 @@ function BoardDetail() {
             }}
           />
         </div>
-
+        {/* 태그 영역 */}
+        {board.tags && board.tags.length > 0 && (
+          <div className="board-tags-container">
+            {board.tags.map((tag, index) => (
+              <Link to={`/search?tag=${tag}`} key={index} className="tag-badge">
+                #{tag}
+              </Link>
+            ))}
+          </div>
+        )}
         {/* 첨부 이미지 */}
         {isImage && (
           <div className="image-section">

--- a/blog_frontend_react/src/components/board/BoardList.jsx
+++ b/blog_frontend_react/src/components/board/BoardList.jsx
@@ -83,7 +83,7 @@ function BoardList() {
   };
 
   const handleWriteClick = () => {
-    alert("로그인이 필요한 서비스입니다.");
+    navigate("/board/write");
   };
 
   const extractImage = (content) => {

--- a/blog_frontend_react/src/components/board/BoardWrite.jsx
+++ b/blog_frontend_react/src/components/board/BoardWrite.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { apiGet, apiPost, apiPut, apiPostJson } from "../../services/api";
 import "./BoardWrite.css";
-
+import TagInput from "./TagInput";
 const allowedTypes = ["image/jpeg", "image/png", "image/gif", "/image/webp"];
 
 function BoardWrite() {
@@ -16,8 +16,10 @@ function BoardWrite() {
     content: "",
   });
 
+  const [tags, setTags] = useState([]);
+
   const [preview, setPreview] = useState(
-    '<p class="text-gray-400 italic">여기에 마크다운 미리보기가 표시됩니다.</p>'
+    '<p class="text-gray-400 italic">여기에 마크다운 미리보기가 표시됩니다.</p>',
   );
   const [statusMessage, setStatusMessage] = useState("");
   const [statusType, setStatusType] = useState("error");
@@ -66,7 +68,7 @@ function BoardWrite() {
     } catch (error) {
       console.error(
         "인증 확인 실패. 로그인 페이지로 이동합니다.",
-        error.message
+        error.message,
       );
       alert("게시글 작성을 위해 로그인이 필요합니다.");
       navigate("/login");
@@ -76,7 +78,8 @@ function BoardWrite() {
   const loadBoardData = async (id) => {
     try {
       const article = await apiGet(`/boards/${id}`);
-
+      console.log(article);
+      console.log(article.tags);
       setFormData({
         title: article.title || "",
         nickname: article.nickname || "",
@@ -84,12 +87,14 @@ function BoardWrite() {
         content: article.content || "",
       });
 
+      setTags(article.tags || []);
+
       updatePreview(article.content || "");
     } catch (error) {
       console.error("수정할 게시글 데이터 로드 실패", error);
       showMessage(
         "게시글 정보를 불러오는데 실패했습니다. 목록으로 돌아갑니다.",
-        "error"
+        "error",
       );
 
       setTimeout(() => {
@@ -109,7 +114,7 @@ function BoardWrite() {
   const updatePreview = async (markdownText) => {
     if (!markdownText.trim()) {
       setPreview(
-        '<p class="text-gray-400 italic">여기에 마크다운 미리보기가 표시됩니다.</p>'
+        '<p class="text-gray-400 italic">여기에 마크다운 미리보기가 표시됩니다.</p>',
       );
       return;
     }
@@ -122,14 +127,14 @@ function BoardWrite() {
     } catch (error) {
       console.error("마크다운 미리보기 실패", error);
       setPreview(
-        '<p class="text-red-500">미리보기 로딩 중 오류가 발생했습니다.</p>'
+        '<p class="text-red-500">미리보기 로딩 중 오류가 발생했습니다.</p>',
       );
     }
   };
 
   const uploadImageToServer = async (file) => {
     console.log(
-      `[Server Upload Processing] 파일명 : ${file.name}, 타입 : ${file.type}`
+      `[Server Upload Processing] 파일명 : ${file.name}, 타입 : ${file.type}`,
     );
 
     const formDataUpload = new FormData();
@@ -148,7 +153,7 @@ function BoardWrite() {
   const updateTextareaContent = (
     text,
     updateAction = "insert",
-    targetText = ""
+    targetText = "",
   ) => {
     const textarea = contentRef.current;
     if (!textarea) return;
@@ -203,7 +208,7 @@ function BoardWrite() {
 
     if (!allowedTypes.includes(imageFile.type)) {
       showMessage(
-        `[${imageFile.type}]은 지원하지 않는 파일 형식입니다. (JPG, PNG 등만 허용)`
+        `[${imageFile.type}]은 지원하지 않는 파일 형식입니다. (JPG, PNG 등만 허용)`,
       );
       return;
     }
@@ -241,6 +246,7 @@ function BoardWrite() {
       nickname: formData.nickname,
       category: formData.category,
       content: formData.content,
+      tags: tags,
     };
 
     try {
@@ -265,7 +271,7 @@ function BoardWrite() {
         `게시글 ${isEditMode ? "수정" : "작성"} 중 오류가 발생했습니다: ${
           error.message
         }`,
-        "error"
+        "error",
       );
     }
   };
@@ -330,6 +336,10 @@ function BoardWrite() {
             </select>
           </div>
 
+          <div className=" form-group">
+            <label>태그</label>
+            <TagInput tags={tags} setTags={setTags} />
+          </div>
           {/* 내용 (마크다운) */}
           <div className="form-group">
             <label htmlFor="content">

--- a/blog_frontend_react/src/components/board/TagInput.css
+++ b/blog_frontend_react/src/components/board/TagInput.css
@@ -1,0 +1,60 @@
+.tag-input-container {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  padding: 5px 10px;
+  background-color: white;
+  min-height: 40px;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.tag-item {
+  display: flex;
+  align-items: center;
+  background-color: #f1f3f5;
+  color: #0ca678; /* 벨로그 스타일 초록색 */
+  padding: 5px 10px;
+  border-radius: 15px;
+  margin-right: 8px;
+  margin-bottom: 5px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  transition: all 0.2s;
+}
+
+.tag-item:hover {
+  background-color: #e6fcf5;
+}
+
+.tag-remove-btn {
+  background: none;
+  border: none;
+  color: #868e96;
+  margin-left: 5px;
+  cursor: pointer;
+  font-size: 1.1rem;
+  padding: 0;
+  line-height: 1;
+}
+
+.tag-remove-btn:hover {
+  color: #ff6b6b;
+}
+
+.tag-input-field {
+  border: none;
+  outline: none;
+  font-size: 1rem;
+  padding: 5px;
+  flex-grow: 1; /* 남은 공간 차지 */
+  min-width: 150px;
+}

--- a/blog_frontend_react/src/components/board/TagInput.jsx
+++ b/blog_frontend_react/src/components/board/TagInput.jsx
@@ -1,0 +1,50 @@
+import React, { useState } from "react";
+import "./TagInput.css";
+
+const TagInput = ({ tags, setTags }) => {
+  const [input, setInput] = useState("");
+
+  const handleKeyDown = (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      const trimmedInput = input.trim();
+
+      if (trimmedInput && !tags.includes(trimmedInput)) {
+        setTags([...tags, trimmedInput]);
+        setInput("");
+      }
+    }
+  };
+
+  const removeTag = (indexToRemove) => {
+    setTags(tags.filter((_, index) => index !== indexToRemove));
+  };
+
+  return (
+    <div className="tag-input-container">
+      <ul className="tag-list">
+        {tags.map((tag, index) => (
+          <li key={index} className="tag-item">
+            <span>#{tag}</span>
+            <button
+              type="button"
+              className="tag-remove-btn"
+              onClick={() => removeTag(index)}
+            >
+              &times;
+            </button>
+          </li>
+        ))}
+      </ul>
+      <input
+        type="text"
+        className="tag-input-filed"
+        placeholder="태그를 입력하고 엔터를 누르세요"
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={handleKeyDown}
+      />
+    </div>
+  );
+};
+export default TagInput;

--- a/blog_frontend_react/src/components/common/Navbar.css
+++ b/blog_frontend_react/src/components/common/Navbar.css
@@ -88,3 +88,19 @@
   background-color: #34495e;
   /* 배경색을 약간 밝게 변경 */
 }
+
+/* 검색 아이콘 링크 스타일 */
+.search-icon-link {
+  font-size: 1.2rem;
+  padding: 10px;
+  border-radius: 50%;
+  transition: background-color 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.search-icon-link:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: white;
+}

--- a/blog_frontend_react/src/components/common/Navbar.jsx
+++ b/blog_frontend_react/src/components/common/Navbar.jsx
@@ -2,12 +2,20 @@ import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "../../contexts/AuthContext";
 import NotificationBell from "./NotificationBell";
 import "./Navbar.css";
+import { useRef, useState } from "react";
 
 const LOGOUT_API_URL = "http://localhost:8000/api/v1/logout";
 
 function Navbar() {
   const { user, logout, isAuthenticated } = useAuth();
   const navigage = useNavigate();
+
+  const handleSearch = (e) => {
+    if (e.key == "Enter" && searchKeyword.trim()) {
+      navigage(`/search?keyword=${searchKeyword}`);
+      setSearchKeyword("");
+    }
+  };
 
   const handleLogout = async (event) => {
     event.preventDefault();
@@ -48,6 +56,14 @@ function Navbar() {
           {/* <li>
             <Link to="/">홈</Link>
           </li> */}
+
+          <ul className="nav-links">
+            <li>
+              <Link to="/search" className="search-icon-link">
+                🔍
+              </Link>
+            </li>
+          </ul>
 
           {isAuthenticated && user?.nickname ? (
             <>
@@ -91,9 +107,9 @@ function Navbar() {
             </>
           )}
 
-          <li>
+          {/* <li>
             <a href="#">문의</a>
-          </li>
+          </li> */}
         </ul>
       </div>
     </nav>

--- a/blog_frontend_react/src/components/common/SearchPage.css
+++ b/blog_frontend_react/src/components/common/SearchPage.css
@@ -1,0 +1,126 @@
+/* 전체 페이지 래퍼 */
+.search-page-container {
+  padding-top: 1.5px;
+  min-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+/* --- 1. 검색창 영역 --- */
+.search-bar-wrapper {
+  width: 100%;
+  max-width: 768px; /* Velog 너비 */
+  margin-bottom: 3rem;
+  padding: 0 1rem;
+}
+
+.search-box {
+  display: flex;
+  align-items: center;
+  border: 1px solid #adb5bd;
+  padding: 10px 15px;
+  border-radius: 4px;
+  transition: all 0.2s;
+}
+
+/* 포커스 됐을 때 검정 테두리 */
+.search-box:focus-within {
+  border-color: #212529;
+}
+
+.search-icon-large {
+  font-size: 1.5rem;
+  margin-right: 15px;
+  color: #868e96;
+}
+
+.search-box input {
+  flex: 1;
+  border: none;
+  outline: none;
+  font-size: 1.5rem; /* 글자 크게 */
+  color: #212529;
+  background-color: #f1f3f5;
+}
+
+/* .search-box input::placeholder {
+  color: #ced4da;
+} */
+
+/* --- 2. 결과 영역 --- */
+.search-results-area {
+  width: 100%;
+  max-width: 768px;
+  padding: 0 1rem;
+}
+
+.status-msg {
+  text-align: center;
+  color: #868e96;
+  font-size: 1.2rem;
+  margin-top: 50px;
+}
+
+.tag-header {
+  font-size: 2rem;
+  margin-bottom: 2rem;
+  color: #12b886; /* Velog 초록색 */
+}
+
+.result-count {
+  margin-bottom: 3rem;
+  color: #495057;
+}
+
+/* 개별 게시글 카드 */
+.result-item {
+  margin-bottom: 4rem;
+  border-bottom: 1px solid #83a1be;
+  padding-bottom: 4rem;
+}
+
+.result-meta-top {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.writer-name {
+  font-weight: bold;
+  color: #212529;
+  font-size: 0.9rem;
+}
+
+.result-link {
+  text-decoration: none;
+  color: inherit;
+}
+
+.result-link h2 {
+  font-size: 1.5rem;
+  margin: 0 0 0.5rem 0;
+  color: #212529;
+  line-height: 1.5;
+}
+
+.result-link h2:hover {
+  color: #12b886; /* 제목 호버 시 초록색 */
+  text-decoration: underline;
+}
+
+.result-summary {
+  font-size: 1rem;
+  color: #495057;
+  margin-bottom: 1.5rem;
+  line-height: 1.6;
+}
+
+.result-meta-bottom {
+  font-size: 0.85rem;
+  color: #868e96;
+}
+
+.separator {
+  margin: 0 5px;
+}

--- a/blog_frontend_react/src/components/common/SearchPage.jsx
+++ b/blog_frontend_react/src/components/common/SearchPage.jsx
@@ -1,0 +1,151 @@
+import { useState, useEffect } from "react";
+import { useSearchParams, Link, useNavigate } from "react-router-dom";
+import "./SearchPage.css";
+
+const SearchPage = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  const keywordParam = searchParams.get("keyword");
+  const tagParam = searchParams.get("tag");
+
+  const [inputText, setInputText] = useState(keywordParam || "");
+  const [results, setResults] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  const handleSearch = (e) => {
+    if (e.key === "Enter" && inputText.trim()) {
+      const trimmedInput = inputText.trim();
+
+      // 1. 입력값이 '#'으로 시작하는지 확인
+      if (trimmedInput.startsWith("#")) {
+        // '#' 제거하고 순수 태그명만 추출
+        const tagName = trimmedInput.slice(1).trim();
+
+        // 태그명이 비어있지 않다면 태그 검색으로 이동
+        if (tagName) {
+          navigate(`/search?tag=${encodeURIComponent(tagName)}`);
+        }
+      } else {
+        // 2. '#'이 없으면 일반 키워드 검색 (글자 자르지 않음!)
+        navigate(`/search?keyword=${encodeURIComponent(trimmedInput)}`);
+      }
+    }
+  };
+  const stripmarkdownAndHtml = (text) => {
+    if (!text) return "";
+    let cleanText = text
+      .replace(/<[^>]*>/g, "")
+      .replace(/!\[.*\]\(.*\)/g, "")
+      .replace(/\[.*\]\(.*\)/g, "")
+      .replace(/[#*|>_`-]/g, "")
+      .replace(/\s+/g, " ")
+      .trim();
+    return cleanText;
+  };
+  useEffect(() => {
+    const fetchSearchResults = async () => {
+      if (!keywordParam && !tagParam) {
+        setResults([]);
+        return;
+      }
+
+      setLoading(true);
+      try {
+        let url = `http://localhost:8000/api/v1/boards/search?`;
+        if (keywordParam) url += `keyword=${encodeURIComponent(keywordParam)}`;
+        if (tagParam) url += `tag=${encodeURIComponent(tagParam)}`;
+
+        const response = await fetch(url);
+        if (response.ok) {
+          const data = await response.json();
+          setResults(data);
+        } else {
+          setResults([]);
+        }
+      } catch (error) {
+        console.error("검색 오류", error);
+        setResults([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (keywordParam) setInputText(keywordParam);
+    else if (tagParam) {
+      setInputText(`#${tagParam}`);
+    }
+    fetchSearchResults();
+  }, [keywordParam, tagParam]);
+
+  return (
+    <div className="search-page-container">
+      {/* 검색창 */}
+      <div className="search-bar-wrapper">
+        <div className="search-box">
+          <span className="search-icon-large">🔍</span>
+          <input
+            type="text"
+            placeholder="검색어를 입력하세요"
+            value={inputText}
+            onChange={(e) => setInputText(e.target.value)}
+            onKeyDown={handleSearch}
+          />
+        </div>
+      </div>
+
+      {/* 검색 결과 영역 */}
+      <div className="search-results-area">
+        {loading ? (
+          <p className="status-msg">검색 중...</p>
+        ) : (
+          <>
+            {/* 태그 검색일 경우 표시 */}
+            {tagParam && <h3 className="tag-header"># {tagParam}</h3>}
+
+            {/* 결과 목록 */}
+            {results.length > 0 ? (
+              <div className="result-list">
+                <p className="result-count">
+                  총 <b>{results.length}</b>개의 포스트를 찾았습니다.
+                </p>
+                {results.map((board) => (
+                  <div key={board.boardId} className="result-item">
+                    {/* 작성자 정보 */}
+                    <div className="result-meta-top">
+                      <span className="writer-name">{board.nickname}</span>
+                    </div>
+                    {/* 게시글 제목/ 내용 */}
+                    <Link
+                      to={`/board/${board.boardId}`}
+                      className="result-link"
+                    >
+                      <h2>{board.title}</h2>
+                    </Link>
+                    <p className="result-summary">
+                      {stripmarkdownAndHtml(board.contentSummary)}
+                    </p>
+                    {/* 하단 정보 (날짜,좋아요 등) */}
+                    <div className="result-meta-bottom">
+                      <span>
+                        {new Date(board.inputDate).toLocaleDateString()}
+                      </span>
+                      <span className="separator">·</span>
+                      <span>❤️ {board.likes}</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              (keywordParam || tagParam) && (
+                <p className="status-msg">검색 결과가 없습니다.</p>
+              )
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SearchPage;

--- a/blog_frontend_react/src/components/member/Login.jsx
+++ b/blog_frontend_react/src/components/member/Login.jsx
@@ -62,7 +62,7 @@ function Login() {
         login({ nickname: result.nickname }, null);
 
         setStatusMessage(
-          `로그인 성공! ${result.nickname}님 환영합니다. 잠시 후 이동합니다.`
+          `로그인 성공! ${result.nickname}님 환영합니다. 잠시 후 이동합니다.`,
         );
         setStatusColor("green");
 
@@ -74,11 +74,7 @@ function Login() {
           message: `상태 코드 ${response.status} 오류`,
         }));
 
-        setStatusMessage(
-          `로그인 실패 ${
-            errorData.message || "아이디 또는 비밀번호가 일치하지 않습니다."
-          }`
-        );
+        setStatusMessage("아이디 또는 비밀번호가 일치하지 않습니다.");
         setStatusColor("red");
       }
     } catch (error) {
@@ -106,7 +102,7 @@ function Login() {
         }
       } else {
         console.error(
-          `카카오 로그인 시작 요청 실패 (상태 : ${response.status})`
+          `카카오 로그인 시작 요청 실패 (상태 : ${response.status})`,
         );
         alert("카카오 로그인 요청에 실패했습니다.");
       }
@@ -132,7 +128,7 @@ function Login() {
         }
       } else {
         console.error(
-          `네이버 로그인 시작 요청 실패 (상태 : ${response.status})`
+          `네이버 로그인 시작 요청 실패 (상태 : ${response.status})`,
         );
         alert("네이버 로그인 요청에 실패했습니다.");
       }
@@ -148,7 +144,7 @@ function Login() {
       <div id="login-status">
         <form id="login-form" onSubmit={handleSubmit}>
           <div>
-            <label htmlFor="username">아이디:</label>
+            <label htmlFor="username">아이디</label>
             <input
               type="text"
               name="username"
@@ -158,7 +154,7 @@ function Login() {
             />
           </div>
           <div>
-            <label htmlFor="password">비밀번호:</label>
+            <label htmlFor="password">비밀번호</label>
             <input
               type="password"
               name="password"


### PR DESCRIPTION
UI/UX 컴포넌트
---
- [x]  Navbar 검색창: 상단 네비게이션 바에 검색어 입력 필드(Search Bar) 및 돋보기 아이콘 추가

- [x]  태그 입력기 (TagInput): 게시글 작성/수정 페이지에 태그를 입력하고 엔터(Enter)로 추가, 'X' 버튼으로 삭제하는 UI 구현

기능 및 API 연동
---
- [x] 게시글 작성/수정:

BoardWrite, BoardEdit 페이지 상태(State)에 tags 배열 추가

API 요청(POST, PUT) 시 tags 데이터를 함께 전송하도록 수정

- [x] 검색 기능 구현:

Navbar 검색창에서 엔터 입력 시 /search?keyword=... 로 라우팅 처리

검색어(keyword) 및 태그(tag) 쿼리 파라미터를 읽어 백엔드 검색 API 호출

검색 결과 목록 렌더링 및 '검색 결과 없음' 상태 처리

- [x] 태그 클릭 검색:

게시글 목록이나 상세 페이지에서 태그 클릭 시 해당 태그 검색 결과 페이지(/search?tag=...)로 이동하는 기능 구현