### PR TITLE
[perf/#49] 검색 페이지 무한 스크롤 및 중복 요청 방지 개선

### DIFF
--- a/blog_frontend_react/src/components/common/SearchPage.jsx
+++ b/blog_frontend_react/src/components/common/SearchPage.jsx
@@ -1,6 +1,8 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useSearchParams, Link, useNavigate } from "react-router-dom";
 import "./SearchPage.css";
+
+const PAGE_SIZE = 20;
 
 const SearchPage = () => {
   const [searchParams] = useSearchParams();
@@ -12,6 +14,15 @@ const SearchPage = () => {
   const [inputText, setInputText] = useState(keywordParam || "");
   const [results, setResults] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [lastBoardId, setLastBoardId] = useState(null);
+  const [hasmore, setHasMore] = useState(false);
+
+  // Intersection Observer target ref
+  const sentineRef = useRef(null);
+
+  //중복 fetch 방지용 ref
+  const isFethcingRef = useRef(false);
 
   const handleSearch = (e) => {
     if (e.key === "Enter" && inputText.trim()) {
@@ -43,40 +54,126 @@ const SearchPage = () => {
       .trim();
     return cleanText;
   };
-  useEffect(() => {
-    const fetchSearchResults = async () => {
+
+  const fetchResults = useCallback(
+    async (cursor = null, isAppend = false) => {
       if (!keywordParam && !tagParam) {
         setResults([]);
         return;
       }
 
-      setLoading(true);
+      if (isFethcingRef.current) return;
+      isFethcingRef.current = true;
+
+      isAppend ? setLoadingMore(true) : setLoading(true);
+
       try {
-        let url = `http://localhost:8000/api/v1/boards/search?`;
-        if (keywordParam) url += `keyword=${encodeURIComponent(keywordParam)}`;
-        if (tagParam) url += `tag=${encodeURIComponent(tagParam)}`;
+        let url = `http://localhost:8000/api/v1/boards/search?size=${PAGE_SIZE}`;
+        if (keywordParam) url += `&keyword=${encodeURIComponent(keywordParam)}`;
+        if (tagParam) url += `&tagName=${encodeURIComponent(tagParam)}`;
+        if (cursor) url += `&lastBoardId=${cursor}`;
 
         const response = await fetch(url);
         if (response.ok) {
           const data = await response.json();
-          setResults(data);
+
+          setResults((prev) => {
+            if (!isAppend) return data;
+            //중복 boardId 제거 후 누적
+            const existingIds = new Set(prev.map((b) => b.boardId));
+            const deduplicated = data.filter(
+              (b) => !existingIds.has(b.boardId),
+            );
+            return [...prev, ...deduplicated];
+          });
+
+          // 받은 데이터가 PAGE_SIZE개면 다음 페이지 있을 수 있음
+          if (data.length == PAGE_SIZE) {
+            setLastBoardId(data[data.length - 1].boardId);
+            setHasMore(true);
+          } else {
+            setLastBoardId(null);
+            setHasMore(false);
+          }
         } else {
-          setResults([]);
+          if (!isAppend) setResults([]);
+          setHasMore(false);
         }
       } catch (error) {
         console.error("검색 오류", error);
-        setResults([]);
+        if (!isAppend) setResults([]);
+        setHasMore(false);
       } finally {
-        setLoading(false);
+        isFethcingRef.current = false;
+        isAppend ? setLoadingMore(false) : setLoading(false);
       }
-    };
+    },
+    [keywordParam, tagParam],
+  );
 
+  useEffect(() => {
     if (keywordParam) setInputText(keywordParam);
-    else if (tagParam) {
-      setInputText(`#${tagParam}`);
-    }
-    fetchSearchResults();
+    else if (tagParam) setInputText(`#${tagParam}`);
+
+    setResults([]);
+    setLastBoardId(null);
+    setHasMore(false);
+    isFethcingRef.current = false;
+    fetchResults(null, false);
   }, [keywordParam, tagParam]);
+
+  // Intersection Observer : sentinel이 보이면 다음 페이지 로드
+  useEffect(() => {
+    if (!sentineRef.current) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const first = entries[0];
+        if (first.isIntersecting && hasmore && !isFethcingRef.current) {
+          fetchResults(lastBoardId, true);
+        }
+      },
+      { threshold: 0.1 },
+    );
+
+    observer.observe(sentineRef.current);
+    return () => observer.disconnect();
+  }, [hasmore, lastBoardId, fetchResults]);
+
+  // useEffect(() => {
+  //   const fetchSearchResults = async () => {
+  //     if (!keywordParam && !tagParam) {
+  //       setResults([]);
+  //       return;
+  //     }
+
+  //     setLoading(true);
+  //     try {
+  //       let url = `http://localhost:8000/api/v1/boards/search?`;
+  //       if (keywordParam) url += `keyword=${encodeURIComponent(keywordParam)}`;
+  //       if (tagParam) url += `tag=${encodeURIComponent(tagParam)}`;
+
+  //       const response = await fetch(url);
+  //       if (response.ok) {
+  //         const data = await response.json();
+  //         setResults(data);
+  //       } else {
+  //         setResults([]);
+  //       }
+  //     } catch (error) {
+  //       console.error("검색 오류", error);
+  //       setResults([]);
+  //     } finally {
+  //       setLoading(false);
+  //     }
+  //   };
+
+  //   if (keywordParam) setInputText(keywordParam);
+  //   else if (tagParam) {
+  //     setInputText(`#${tagParam}`);
+  //   }
+  //   fetchSearchResults();
+  // }, [keywordParam, tagParam]);
 
   return (
     <div className="search-page-container">
@@ -108,7 +205,9 @@ const SearchPage = () => {
               <div className="result-list">
                 <p className="result-count">
                   총 <b>{results.length}</b>개의 포스트를 찾았습니다.
+                  {hasmore && " (더 있음)"}
                 </p>
+
                 {results.map((board) => (
                   <div key={board.boardId} className="result-item">
                     {/* 작성자 정보 */}
@@ -135,6 +234,19 @@ const SearchPage = () => {
                     </div>
                   </div>
                 ))}
+
+                {/* 무한 스크롤 sentinel */}
+                <div ref={sentineRef} style={{ height: "1px" }} />
+
+                {/* 추가 로딩 스피너 */}
+                {loadingMore && <p className="status-msg">불러오는 중...</p>}
+
+                {/* 마지막 페이지 안내 */}
+                {!hasmore && results.length > 0 && (
+                  <p className="status-msg end-msg">
+                    모든 결과를 불러왔습니다.
+                  </p>
+                )}
               </div>
             ) : (
               (keywordParam || tagParam) && (


### PR DESCRIPTION
백엔드 부하 테스트(#33)에서 확인된 검색 병목 구간 개선에 맞춰,
프론트엔드 검색 페이지도 불필요한 API 요청을 줄이고 UX를 개선

커서 기반 무한 스크롤 도입
lastBoardId를 커서로 사용하는 페이징 API 연동
Intersection Observer로 sentinel 감지 시 다음 페이지 자동 로드
초기 로딩(loading)과 추가 로딩(loadingMore) 상태 분리
중복 요청 방지
isFetchingRef(useRef) 도입으로 Observer 중복 트리거 차단
useState 기반 가드는 비동기 특성상 콜백에서 stale 값을 읽어 중복 발화 가능
ref는 동기적으로 즉시 읽히므로 안전
누적 결과에서 중복 boardId Set 필터링 적용