### PR TITLE
[fix/#51] 카카오, 구글 Oauth 로그인 오류 수정 및 인증 방식 통일

### DIFF
--- a/blog_frontend_react/src/components/member/Mypage.jsx
+++ b/blog_frontend_react/src/components/member/Mypage.jsx
@@ -26,15 +26,15 @@ function Mypage() {
       color: "#0c5460",
     });
 
-    const token =
-      sessionStorage.getItem("jwtToken") || localStorage.getItem("jwtToken");
+    // const token =
+    //   sessionStorage.getItem("jwtToken") || localStorage.getItem("jwtToken");
 
     try {
       const response = await fetch(MYPAGE_API_URL, {
         method: "GET",
         headers: {
           "Content-Type": "application/json",
-          ...(token && { Authorization: `Bearer ${token}` }),
+          // ...(token && { Authorization: `Bearer ${token}` }),
         },
         credentials: "include",
       });

--- a/blog_frontend_react/src/contexts/AuthContext.jsx
+++ b/blog_frontend_react/src/contexts/AuthContext.jsx
@@ -10,11 +10,11 @@ export const AuthProvider = ({ children }) => {
   useEffect(() => {
     const checkAuth = () => {
       const urlParams = new URLSearchParams(window.location.search);
-      const jwtToken = urlParams.get("token");
+      // const jwtToken = urlParams.get("token");
       const userNickname = urlParams.get("nickname");
 
-      if (jwtToken && userNickname) {
-        sessionStorage.setItem("jwtToken", jwtToken);
+      if (userNickname) {
+        // sessionStorage.setItem("jwtToken", jwtToken);
         sessionStorage.setItem("isLoggedIn", "true");
         sessionStorage.setItem("userNickname", userNickname);
         window.history.replaceState(
@@ -26,10 +26,10 @@ export const AuthProvider = ({ children }) => {
 
       const isLoggedIn = sessionStorage.getItem("isLoggedIn") == "true";
       const storedNickname = sessionStorage.getItem("userNickname");
-      const storedToken = sessionStorage.getItem("jwtToken");
+      // const storedToken = sessionStorage.getItem("jwtToken");
 
-      if (isLoggedIn && storedNickname && storedToken) {
-        setUser({ nickname: storedNickname, token: storedToken });
+      if (isLoggedIn && storedNickname) {
+        setUser({ nickname: storedNickname });
       }
       setLoading(false);
     };

--- a/blog_frontend_react/src/services/api.js
+++ b/blog_frontend_react/src/services/api.js
@@ -21,10 +21,10 @@ function getToken() {
 
 api.interceptors.request.use(
   (config) => {
-    const token = getToken();
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
+    // const token = getToken();
+    // if (token) {
+    //   config.headers.Authorization = `Bearer ${token}`;
+    // }
     return config;
   },
   (error) => {


### PR DESCRIPTION
AuthContext.jsx : 카카오 콜백 URL 에서 nickname 파라미터만 읽도록 수정 (token 제거), jwtToken 없이도 로그인 상태 유지
api.js : interceptor 에서 Authorization 헤더 추가 로직 제거, HttpOnly 쿠키 방식으로 인증 통일
Mypage.jsx Authorization 헤더 전송 코드 제거, credentials : include 의 쿠키 자동 전송으로 인증 처리

resolves: #51